### PR TITLE
Update ingest vendored

### DIFF
--- a/ingest/README.md
+++ b/ingest/README.md
@@ -39,15 +39,5 @@ in the main Snakefile in the order that they are expected to run.
 This repository uses [`git subrepo`](https://github.com/ingydotnet/git-subrepo)
 to manage copies of ingest scripts in [vendored](vendored), from [nextstrain/ingest](https://github.com/nextstrain/ingest).
 
-To pull new changes from the central ingest repository, first install `git subrepo`,
-then from the top level directory of the repo run:
-
-```sh
-git subrepo pull ingest/vendored
-```
-
-Changes should not be pushed using `git subrepo push`.
-
-1. For pathogen-specific changes, make them in this repository via a pull request.
-2. For pathogen-agnostic changes, make them on [nextstrain/ingest](https://github.com/nextstrain/ingest)
-   via pull request there, then use `git subrepo pull` to add those changes to this repository.
+See [vendored/README.md](vendored/README.md#vendoring) for instructions on how to update
+the vendored scripts.

--- a/ingest/config/defaults.yaml
+++ b/ingest/config/defaults.yaml
@@ -43,6 +43,11 @@ curate:
     Isolate Lineage source: sample_type
     BioSample accession: biosample_accession
     Submitter Country: submitter_country
+  # Standardized strain name regex
+  # Currently accepts any characters because we do not have a clear standard for strain names across pathogens
+  strain_regex: '^.+$'
+  # Back up strain name field to use if 'strain' doesn't match regex above
+  strain_backup_fields: ['accession']
   # List of date fields to standardize to ISO format YYYY-MM-DD
   date_fields: []
   # List of expected date formats that are present in the date fields provided above

--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -63,6 +63,8 @@ rule curate:
         "benchmarks/curate.txt"
     params:
         field_map=format_field_map(config["curate"]["field_map"]),
+        strain_regex=config["curate"]["strain_regex"],
+        strain_backup_fields=config["curate"]["strain_backup_fields"],
         date_fields=config["curate"]["date_fields"],
         expected_date_formats=config["curate"]["expected_date_formats"],
         articles=config["curate"]["titlecase"]["articles"],
@@ -80,6 +82,9 @@ rule curate:
             | ./vendored/transform-field-names \
                 --field-map {params.field_map} \
             | augur curate normalize-strings \
+            | ./vendored/transform-strain-names \
+                --strain-regex {params.strain_regex} \
+                --backup-fields {params.strain_backup_fields} \
             | augur curate format-dates \
                 --date-fields {params.date_fields} \
                 --expected-date-formats {params.expected_date_formats} \

--- a/ingest/vendored/.github/workflows/ci.yaml
+++ b/ingest/vendored/.github/workflows/ci.yaml
@@ -13,3 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: nextstrain/.github/actions/shellcheck@master
+
+  cram:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - run: pip install cram
+      - run: cram tests/

--- a/ingest/vendored/.gitrepo
+++ b/ingest/vendored/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/nextstrain/ingest
 	branch = main
-	commit = 9cfed8b1a93e881d85a71aef46e66730ca660523
-	parent = 143581871f1fdcc3ce0d020e1c3ddddffef2ffa9
+	commit = 7617c39fae05e5882c5e6c065c5b47d500c998af
+	parent = d49aeeb0a95f6336a516b3f25fa83a67d16bf56e
 	method = merge
 	cmdver = 0.4.6

--- a/ingest/vendored/README.md
+++ b/ingest/vendored/README.md
@@ -25,6 +25,31 @@ Any future updates of ingest scripts can be pulled in with:
 git subrepo pull ingest/vendored
 ```
 
+If you run into merge conflicts and would like to pull in a fresh copy of the
+latest ingest scripts, pull with the `--force` flag:
+
+```
+git subrepo pull ingest/vendored --force
+```
+
+> **Warning**
+> Beware of rebasing/dropping the parent commit of a `git subrepo` update
+
+`git subrepo` relies on metadata in the `ingest/vendored/.gitrepo` file,
+which includes the hash for the parent commit in the pathogen repos.
+If this hash no longer exists in the commit history, there will be errors when
+running future `git subrepo pull` commands.
+
+If you run into an error similar to the following:
+```
+$ git subrepo pull ingest/vendored
+git-subrepo: Command failed: 'git branch subrepo/ingest/vendored '.
+fatal: not a valid object name: ''
+```
+Check the parent commit hash in the `ingest/vendored/.gitrepo` file and make
+sure the commit exists in the commit history. Update to the appropriate parent
+commit hash if needed.
+
 ## History
 
 Much of this tooling originated in
@@ -96,6 +121,7 @@ Potential augur curate scripts
 - [transform-authors](transform-authors) - Abbreviates full author lists to '<first author> et al.'
 - [transform-field-names](transform-field-names) - Rename fields of NDJSON records
 - [transform-genbank-location](transform-genbank-location) - Parses `location` field with the expected pattern `"<country_value>[:<region>][, <locality>]"` based on [GenBank's country field](https://www.ncbi.nlm.nih.gov/genbank/collab/country/)
+- [transform-strain-names](transform-strain-names) - Ordered search for strain names across several fields.
 
 ## Software requirements
 

--- a/ingest/vendored/tests/transform-strain-names/transform-strain-names.t
+++ b/ingest/vendored/tests/transform-strain-names/transform-strain-names.t
@@ -1,0 +1,17 @@
+Look for strain name in "strain" or a list of backup fields.
+
+If strain entry exists, do not do anything.
+
+  $ echo '{"strain": "i/am/a/strain", "strain_s": "other"}' \
+  >   | $TESTDIR/../../transform-strain-names \
+  >       --strain-regex '^.+$' \
+  >       --backup-fields strain_s accession
+  {"strain":"i/am/a/strain","strain_s":"other"}
+
+If strain entry does not exists, search the backup fields
+
+  $ echo '{"strain_s": "other"}' \
+  >   | $TESTDIR/../../transform-strain-names \
+  >       --strain-regex '^.+$' \
+  >       --backup-fields accession strain_s 
+  {"strain_s":"other","strain":"other"}

--- a/ingest/vendored/transform-strain-names
+++ b/ingest/vendored/transform-strain-names
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Verifies strain name pattern in the 'strain' field of the NDJSON record from
+stdin. Adds a 'strain' field to the record if it does not already exist.
+
+Outputs the modified records to stdout.
+"""
+import argparse
+import json
+import re
+from sys import stderr, stdin, stdout
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--strain-regex", default="^.+$",
+        help="Regex pattern for strain names. " +
+             "Strain names that do not match the pattern will be dropped.")
+    parser.add_argument("--backup-fields", nargs="*",
+        help="List of backup fields to use as strain name if the value in 'strain' " +
+             "does not match the strain regex pattern. " +
+             "If multiple fields are provided, will use the first field that has a non-empty string.")
+
+    args = parser.parse_args()
+
+    strain_name_pattern = re.compile(args.strain_regex)
+
+    for index, record in enumerate(stdin):
+        record = json.loads(record)
+
+        # Verify strain name matches the strain regex pattern
+        if strain_name_pattern.match(record.get('strain', '')) is None:
+            # Default to empty string if not matching pattern
+            record['strain'] = ''
+            # Use non-empty value of backup fields if provided
+            if args.backup_fields:
+                for field in args.backup_fields:
+                    if record.get(field):
+                        record['strain'] = str(record[field])
+                        break
+
+        if record['strain'] == '':
+            print(f"WARNING: Record number {index} has an empty string as the strain name.", file=stderr)
+
+
+        json.dump(record, stdout, allow_nan=False, indent=None, separators=',:')
+        print()


### PR DESCRIPTION
Pulling in the latest [nextstrain/ingest](https://github.com/nextstrain/ingest) before I make Nextstrain automation profiles that use the ingest scripts. Turns out the template already had the latest scripts required for Nextstrain automation rules. This just pulled in the centralized `transform-strain-names` script, which I've added to the curation pipeline. 

