### PR TITLE
handle bare quotes in fields

### DIFF
--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -82,7 +82,7 @@ rule format_ncbi_dataset_report:
             --package {input.dataset_package} \
             --fields {params.ncbi_datasets_fields:q} \
             --elide-header \
-            | csvtk add-header -t -n {params.ncbi_datasets_fields:q} \
+            | csvtk add-header -t -l -n {params.ncbi_datasets_fields:q} \
             > {output.ncbi_dataset_tsv}
         """
 


### PR DESCRIPTION
## Description of proposed changes

Some of the fields in NCBI contain values with internal double quotes like:

```
UMR "Emergence des Pathologies Virales" (EPV: Aix-Marseille Univ-IRD190-INSERM1207-EHESP-IHU Mediterranee Infection)
```

which causes csvtk to throw error:

```
bare `"` in non-quoted-field.
```

The suggested fix is to add a `-l` flag shown in case 7 at:
 https://bioinf.shenwei.me/csvtk/usage/#:~:text=7.-,If%20double%2Dquotes%20exist%20in%20fields%20not%20enclosed%20with%20double,%2Dquotes%22%20to%20fix%20it.


## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
