### PR TITLE
Version nextclade binary for transition, i.e. nextclade -> nextclade2

### DIFF
--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -29,7 +29,7 @@ rule get_nextclade_dataset:
         dataset_name=DATASET_NAME
     shell:
         """
-        nextclade dataset get \
+        nextclade2 dataset get \
             --name={params.dataset_name:q} \
             --output-zip={output.dataset} \
             --verbose
@@ -50,7 +50,7 @@ rule run_nextclade:
         translations=lambda w: "results/translations/{gene}.fasta",
     shell:
         """
-        nextclade run \
+        nextclade2 run \
             {input.sequences} \
             --input-dataset {input.dataset} \
             --output-tsv {output.nextclade} \

--- a/nextclade/profiles/test_dataset/test_dataset.smk
+++ b/nextclade/profiles/test_dataset/test_dataset.smk
@@ -12,7 +12,7 @@ rule test_dataset:
         dataset_dir="datasets/{build_name}",
     shell:
         """
-        nextclade run \
+        nextclade2 run \
             {input.sequences} \
             --input-dataset {params.dataset_dir} \
             --output-all {output.outdir}


### PR DESCRIPTION
Soon we will release nextclade v3. Once nextclade v3 hits bioconda, workflows that rely on v2 syntax will break. To prevent this, this PR makes it explicit that the syntax used is for v2 and that the v2 binary nextclade2 should be used.

This binary is in both the nextstrain-base docker image and in the conda-base managed conda environment.

Users who don't use either will have to add nextclade2 to the path.

Over the next few weeks, we will transition repos to use nextclade3. The reason to add nextclade2 now is so that workflows don't break if they haven't yet transitioned to nextclade3 at the time of v3 release. It also makes it easy to search which workflows need to be changed.
